### PR TITLE
Avoid translating jap

### DIFF
--- a/python/translator.py
+++ b/python/translator.py
@@ -2,6 +2,7 @@ import json
 
 from openai import OpenAI
 
+from enum import Enum
 import os
 import sys
 import time
@@ -17,10 +18,47 @@ def main():
     with open(full_filename, "r") as f:
         content = f.read()
 
+    jp = analyze_text(content)
+    if jp > 0.5:
+        return
+
     translated_text = translate_md(content)
 
     with open(full_filename, "w") as f:
         f.write(translated_text)
+
+
+class Script(Enum):
+    LATIN = "latin"
+    JAPANESE = "japanese"
+    OTHER = "other"
+
+
+def categorize_character(char):
+    code_point = ord(char)
+
+    # Latin script ranges (including extended)
+    if (0x0041 <= code_point <= 0x005A) or (0x0061 <= code_point <= 0x007A) or \
+            (0x00C0 <= code_point <= 0x00FF) or (0x0100 <= code_point <= 0x024F):
+        return Script.LATIN
+
+    # Japanese script ranges (simplified, includes common Hiragana, Katakana, and Kanji)
+    if (0x3040 <= code_point <= 0x309F) or \
+            (0x30A0 <= code_point <= 0x30FF) or \
+            (0x4E00 <= code_point <= 0x9FAF) or \
+            (0x3400 <= code_point <= 0x4DBF):  # Additional range for CJK Unified Ideographs Extension
+        return Script.JAPANESE
+
+    return Script.OTHER
+
+
+def analyze_text(t: str) -> float:
+    script_counts = {k: 0 for k in Script}
+    for char in t:
+        category = categorize_character(char)
+        script_counts[category] += 1
+
+    return script_counts[Script.JAPANESE] / (script_counts[Script.JAPANESE] + script_counts[Script.LATIN])
 
 
 def translate_md(inp: str) -> str:

--- a/python/translator.py
+++ b/python/translator.py
@@ -19,6 +19,7 @@ def main():
         content = f.read()
 
     jp = analyze_text(content)
+    print(f"Japanese text score: {(jp*100):.2f}%")
     if jp > 0.5:
         return
 
@@ -80,7 +81,7 @@ def translate_md(inp: str) -> str:
             thread_id=thread.id
         )
 
-        print(messages.data[0].content[0].text.value)
+        # print(messages.data[0].content[0].text.value)
 
         return messages.data[0].content[0].text.value
 


### PR DESCRIPTION
This PR will avoid translating japanese text by measuring the ratio of japanese to latin characters.

Current score: >50% japanese will not be sent to the translator