### PR TITLE
quicker deployments

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,15 +17,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-
-      - name: Setup Go
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: go.mod
-      - name: Store Images
-        run: |
-          go run go/imager/imager.go
-
       - name: "install hugo"
         uses: peaceiris/actions-hugo@v2
         with:
@@ -34,6 +25,21 @@ jobs:
         run: |
           cd site
           hugo --minify
+      - uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_DEVHOUSE_80936 }}'
+          channelId: live
+          projectId: devhouse-80936
+
+      # Cache and redeploy, allows posts to be deployed quicker
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+      - name: Store Images
+        run: |
+          go run go/imager/imager.go
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
move image caching to after firebase deploy, then redeploy again

this will allow small changes such as posts to get initially deployed quickly while image caching can happen after