### PR TITLE
Add auto theme detection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.0
 require (
 	github.com/dsoprea/go-jpeg-image-structure/v2 v2.0.0-20221012074422-4f3f7e934102
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
+	golang.org/x/sync v0.7.0
 )
 
 require (
@@ -17,6 +18,5 @@ require (
 	github.com/go-xmlfmt/xmlfmt v1.1.2 // indirect
 	github.com/golang/geo v0.0.0-20230421003525-6adc56603217 // indirect
 	golang.org/x/net v0.22.0 // indirect
-	golang.org/x/sync v0.7.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/site/themes/devhouse-theme/layouts/_default/baseof.html
+++ b/site/themes/devhouse-theme/layouts/_default/baseof.html
@@ -54,13 +54,6 @@
         applyTheme(newTheme);
     }
 
-    // Listen for system preference changes (if not manually set)
-    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
-        if (!localStorage.getItem('theme')) {
-            const newTheme = e.matches ? 'dark' : 'light';
-            applyTheme(newTheme);
-        }
-    });
 
     // Mobile collapsible sidebar and theme initialization
     document.addEventListener('DOMContentLoaded', function() {

--- a/site/themes/devhouse-theme/layouts/_default/baseof.html
+++ b/site/themes/devhouse-theme/layouts/_default/baseof.html
@@ -39,12 +39,7 @@
     }
 
     function getPreferredTheme() {
-        // Returns localStorage preference or system preference
-        let theme = localStorage.getItem('theme');
-        if (!theme) {
-            theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-        }
-        return theme;
+        return window.getPreferredTheme();
     }
 
     function toggleTheme() {

--- a/site/themes/devhouse-theme/layouts/_default/baseof.html
+++ b/site/themes/devhouse-theme/layouts/_default/baseof.html
@@ -20,7 +20,17 @@
 </div>
 {{ partial "footer.html" . }}
 <script>
-    // Theme toggle functionality
+    // Theme functionality
+    function applyTheme(theme) {
+        const darkStylesheet = document.getElementById('theme-dark');
+        const lightStylesheet = document.getElementById('theme-light');
+        if (darkStylesheet && lightStylesheet) {
+            darkStylesheet.disabled = (theme !== 'dark');
+            lightStylesheet.disabled = (theme === 'dark');
+        }
+        updateLogo(theme);
+    }
+
     function updateLogo(theme) {
         const logo = document.getElementById('site-logo');
         if (logo) {
@@ -28,30 +38,35 @@
         }
     }
 
-    function toggleTheme() {
-        const currentTheme = localStorage.getItem('theme') || 'light';
-        const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-
-        const darkStylesheet = document.getElementById('theme-dark');
-        const lightStylesheet = document.getElementById('theme-light');
-
-        if (newTheme === 'light') {
-            darkStylesheet.disabled = true;
-            lightStylesheet.disabled = false;
-        } else {
-            darkStylesheet.disabled = false;
-            lightStylesheet.disabled = true;
+    function getPreferredTheme() {
+        // Returns localStorage preference or system preference
+        let theme = localStorage.getItem('theme');
+        if (!theme) {
+            theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
-
-        localStorage.setItem('theme', newTheme);
-        updateLogo(newTheme);
+        return theme;
     }
 
-    // Mobile collapsible sidebar
+    function toggleTheme() {
+        const currentTheme = getPreferredTheme();
+        const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+        localStorage.setItem('theme', newTheme);
+        applyTheme(newTheme);
+    }
+
+    // Listen for system preference changes (if not manually set)
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
+        if (!localStorage.getItem('theme')) {
+            const newTheme = e.matches ? 'dark' : 'light';
+            applyTheme(newTheme);
+        }
+    });
+
+    // Mobile collapsible sidebar and theme initialization
     document.addEventListener('DOMContentLoaded', function() {
-        // Initialize logo based on current theme
-        const currentTheme = localStorage.getItem('theme') || 'light';
-        updateLogo(currentTheme);
+        // Initialize theme and logo
+        const theme = getPreferredTheme();
+        applyTheme(theme);
 
         // Theme toggle button
         const themeToggle = document.getElementById('theme-toggle');
@@ -62,6 +77,7 @@
             });
         }
 
+        // Mobile sidebar behavior
         if (window.innerWidth <= 1400) {
             const sidebar = document.querySelector('div.左-ナビ');
             if (sidebar) {

--- a/site/themes/devhouse-theme/layouts/_default/baseof.html
+++ b/site/themes/devhouse-theme/layouts/_default/baseof.html
@@ -32,6 +32,13 @@
     }
 
     function updateLogo(theme) {
+        // Process any queued logo updates from head.html
+        if (window.updateLogoQueue && window.updateLogoQueue.length > 0) {
+            while (window.updateLogoQueue.length > 0) {
+                const queuedTheme = window.updateLogoQueue.shift();
+                updateLogo(queuedTheme);
+            }
+        }
         const logo = document.getElementById('site-logo');
         if (logo) {
             logo.src = theme === 'light' ? '/images/logo-dark.svg' : '/images/logo-white.svg';

--- a/site/themes/devhouse-theme/layouts/partials/head.html
+++ b/site/themes/devhouse-theme/layouts/partials/head.html
@@ -10,11 +10,25 @@
     <script>
         // Load theme preference before page render to avoid flash
         (function() {
-            const theme = localStorage.getItem('theme') || 'light';
-            if (theme === 'dark') {
-                document.getElementById('theme-dark').disabled = false;
-                document.getElementById('theme-light').disabled = true;
+            function applyTheme(theme) {
+                document.getElementById('theme-dark').disabled = (theme !== 'dark');
+                document.getElementById('theme-light').disabled = (theme === 'dark');
             }
+
+            // Detect saved preference or system preference
+            let theme = localStorage.getItem('theme');
+            if (!theme) {
+                theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+            }
+            applyTheme(theme);
+
+            // Listen for system preference changes
+            window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
+                if (!localStorage.getItem('theme')) {
+                    applyTheme(e.matches ? 'dark' : 'light');
+                    if (window.updateLogo) updateLogo(e.matches ? 'dark' : 'light');
+                }
+            });
         })();
     </script>
 </head>

--- a/site/themes/devhouse-theme/layouts/partials/head.html
+++ b/site/themes/devhouse-theme/layouts/partials/head.html
@@ -38,7 +38,7 @@
                 if (!localStorage.getItem('theme')) {
                     const newTheme = e.matches ? 'dark' : 'light';
                     applyTheme(newTheme);
-                    if (window.updateLogo) updateLogo(newTheme);
+                    if (window.updateLogo) window.updateLogo(newTheme);
                 }
             });
         })();

--- a/site/themes/devhouse-theme/layouts/partials/head.html
+++ b/site/themes/devhouse-theme/layouts/partials/head.html
@@ -32,8 +32,9 @@
             // Listen for system preference changes
             window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
                 if (!localStorage.getItem('theme')) {
-                    applyTheme(e.matches ? 'dark' : 'light');
-                    if (window.updateLogo) updateLogo(e.matches ? 'dark' : 'light');
+                    const newTheme = e.matches ? 'dark' : 'light';
+                    applyTheme(newTheme);
+                    if (window.updateLogo) updateLogo(newTheme);
                 }
             });
         })();

--- a/site/themes/devhouse-theme/layouts/partials/head.html
+++ b/site/themes/devhouse-theme/layouts/partials/head.html
@@ -8,9 +8,12 @@
     <script src="/js/lazy.js"></script>
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     <script>
-        // Ensure updateLogo is always defined to avoid runtime errors
+        // Queueing stub for updateLogo to avoid race condition
         if (!window.updateLogo) {
-            window.updateLogo = function(theme) {};
+            window.updateLogoQueue = [];
+            window.updateLogo = function(theme) {
+                window.updateLogoQueue.push(theme);
+            };
         }
         // Load theme preference before page render to avoid flash
         (function() {

--- a/site/themes/devhouse-theme/layouts/partials/head.html
+++ b/site/themes/devhouse-theme/layouts/partials/head.html
@@ -15,6 +15,14 @@
                 window.updateLogoQueue.push(theme);
             };
         }
+
+        window.getPreferredTheme = function() {
+            let theme = localStorage.getItem('theme');
+            if (!theme) {
+                theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+            }
+            return theme;
+        };
         // Load theme preference before page render to avoid flash
         (function() {
             function applyTheme(theme) {
@@ -22,11 +30,7 @@
                 document.getElementById('theme-light').disabled = (theme === 'dark');
             }
 
-            // Detect saved preference or system preference
-            let theme = localStorage.getItem('theme');
-            if (!theme) {
-                theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-            }
+            let theme = window.getPreferredTheme();
             applyTheme(theme);
 
             // Listen for system preference changes

--- a/site/themes/devhouse-theme/layouts/partials/head.html
+++ b/site/themes/devhouse-theme/layouts/partials/head.html
@@ -8,6 +8,10 @@
     <script src="/js/lazy.js"></script>
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     <script>
+        // Ensure updateLogo is always defined to avoid runtime errors
+        if (!window.updateLogo) {
+            window.updateLogo = function(theme) {};
+        }
         // Load theme preference before page render to avoid flash
         (function() {
             function applyTheme(theme) {


### PR DESCRIPTION
reads `prefers-color-scheme` to auto-set the website theme to light or dark based on user browser/system preferences.