### PR TITLE
Fix workflow permissions for nested update-imager-cache job

### DIFF
--- a/.github/workflows/archiver.yaml
+++ b/.github/workflows/archiver.yaml
@@ -83,6 +83,9 @@ jobs:
     needs: update-gallery
     if: needs.post.outputs.valid == 'true'
     secrets: inherit
+    permissions:
+      contents: write
+      pull-requests: write
 
   close-issue:
     name: Close issue

--- a/.github/workflows/poster.yaml
+++ b/.github/workflows/poster.yaml
@@ -103,6 +103,9 @@ jobs:
     needs: update-gallery
     if: needs.post.outputs.valid == 'true'
     secrets: inherit
+    permissions:
+      contents: write
+      pull-requests: write
 
   reactions:
     name: React


### PR DESCRIPTION
Add required permissions (contents: write, pull-requests: write) to deploy jobs in poster.yaml and archiver.yaml workflows to allow the nested update-imager-cache job to function properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)